### PR TITLE
chore: move lintstaged config to .lintstagedrc.js

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "**/*": ["prettier --write --ignore-unknown", "eslint"],
+};

--- a/package.json
+++ b/package.json
@@ -2,12 +2,6 @@
   "name": "ttg-server",
   "version": "0.0.1",
   "private": true,
-  "lint-staged": {
-    "**/*": [
-      "prettier --write --ignore-unknown",
-      "eslint"
-    ]
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "cross-env LOG_LEVEL=debug nodemon --exec ts-node src/index.ts",


### PR DESCRIPTION
**Reference to Related Issue**

N/A

**Proposed Changes**

For consistency with https://github.com/tabletop-generator/client, move lintstaged config into `.lintstagedrc.js`

- [x] Remove lint-staged from `package.json`
- [x] Create `.lintstagedrc.js`