### PR TITLE
Make VSCode workspace editor settings match Prettier defaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.detectIndentation": false,
   "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
   "files.eol": "\n",
   "files.insertFinalNewline": true
 }


### PR DESCRIPTION
**Reference to Related Issue**

Fixes #27 

**Proposed Changes**

- [x] Insert spaces instead of tabs
- [x] Set tab size to 2

