### PR TITLE
Dont push docker image on pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-  docker-hub:
-    name: Build and Push to Docker Hub
+  docker-build:
+    name: Build Docker image
     # Don't bother running this job unless the other three all pass
     needs: [lint, dockerfile-lint, unit-tests]
     runs-on: ubuntu-latest
@@ -77,24 +77,57 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login to Docker Hub using GitHub secrets, see:
-      # https://github.com/docker/login-action
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # Build and Push an Image to Docker Hub
-      - name: Build and push
+      # Build Docker image
+      - name: Build and export
         env:
           # Define an Environment Variable with our Docker Hub Repo
-          DOCKERHUB_REPO: usrana/ttg-server
+          DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/ttg-server
           # Define an Environment Variable with the current git commit's sha
           # Use the `github` context to get this, see:
           # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
           SHA_TAG: sha-${{ github.sha }}
         uses: docker/build-push-action@v6
         with:
-          push: true
-          tags: ${{ env.DOCKERHUB_REPO }}:${{ env.SHA_TAG }}, ${{ env.DOCKERHUB_REPO }}:latest, ${{ env.DOCKERHUB_REPO }}:main
+          tags: ${{ env.DOCKERHUB_REPO }}:latest,${{ env.DOCKERHUB_REPO }}:${{ github.sha }},${{ env.DOCKERHUB_REPO }}:main
+          outputs: type=docker,dest=/tmp/image.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: image
+          path: /tmp/image.tar
+
+  docker-hub:
+    name: Push image to Docker Hub
+    needs: [docker-build]
+    # Push only on commits to main i.e. don't push on pull requests
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: image
+          path: /tmp
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Load image
+        run: |
+          docker load --input /tmp/image.tar
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to Docker Hub
+        env:
+          DOCKERHUB_REPO: ${{ secrets.DOCKER_USERNAME }}/ttg-server
+          SHA_TAG: sha-${{ github.sha }}
+        run: |
+          docker push ${{ env.DOCKERHUB_REPO }}:latest
+          docker push ${{ env.DOCKERHUB_REPO }}:${{ env.SHA_TAG }}
+          docker push ${{ env.DOCKERHUB_REPO }}:main


### PR DESCRIPTION
**Reference to Related Issue**

N/A

**Proposed Changes**

- [x] Separate build and push jobs. Push will only run on commits to main and not on PRs.
