### PR TITLE
fix invalid image tag in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           SHA_TAG: sha-${{ github.sha }}
         uses: docker/build-push-action@v6
         with:
-          tags: ${{ env.DOCKERHUB_REPO }}:latest,${{ env.DOCKERHUB_REPO }}:${{ github.sha }},${{ env.DOCKERHUB_REPO }}:main
+          tags: ${{ env.DOCKERHUB_REPO }}:latest,${{ env.DOCKERHUB_REPO }}:${{ env.SHA_TAG }},${{ env.DOCKERHUB_REPO }}:main
           outputs: type=docker,dest=/tmp/image.tar
 
       - name: Upload artifact


### PR DESCRIPTION
**Reference to Related Issue**

N/A

**Proposed Changes**

- [x] use env.SHA_TAG instead of github.sha
