### PR TITLE
fix: wrong github url link in health check

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,7 +18,7 @@ router.get("/", (req, res) => {
   // Send a 200 'OK' response with info about our repo
   return res.status(200).json(
     createSuccessResponse({
-      githubUrl: "https://github.com/uday-rana/fragments",
+      githubUrl: "https://github.com/tabletop-generator/server",
       version,
     }),
   );


### PR DESCRIPTION
**Reference to Related Issue**

N/A

**Proposed Changes**

- [x] change github url link to https://github.com/tabletop-generator/server/
